### PR TITLE
"Fix" OpAnd

### DIFF
--- a/astcomp/compexp.go
+++ b/astcomp/compexp.go
@@ -25,6 +25,9 @@ func (c *expCompiler) ProcessBFunctionCallExp(f ast.BFunctionCall) {
 
 // ProcessBinOpExp compiles a BinOpExp.
 func (c *expCompiler) ProcessBinOpExp(b ast.BinOp) {
+	if b.OpType == 1 { // HACK
+		b.OpType += 0x100;
+	}
 	if b.OpType == ops.OpAnd {
 		c.compileLogicalOp(b, true)
 		return


### PR DESCRIPTION
This is just a hack, I think there is an uint -> uint8 overflow somewhere that I can't find, that or there is something weird happening with enums.
The bug: 
```
	if b.OpType == ops.OpAnd {
```
is false even when b.OpType IS equal to ops.OpAnd (somehow?), so it falls back on `	lsrc := c.compileExpNoDestHint(b.Left)` and the code below it. 